### PR TITLE
Update signalfx to latest release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,15 @@
 PATH
   remote: .
   specs:
-    better_fx (1.0.0)
+    better_fx (1.0.1)
       activesupport (~> 4)
-      signalfx (~> 0.1)
+      signalfx (~> 1.0, >= 1.0.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.7.1)
+    activesupport (4.2.8)
       i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
@@ -24,15 +23,17 @@ GEM
     debugger-linecache (1.2.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    domain_name (0.5.20160826)
+    domain_name (0.5.20170223)
       unf (>= 0.0.5, < 1.0.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    i18n (0.7.0)
+    i18n (0.8.1)
     json (1.8.3)
     middleware (0.1.0)
-    mime-types (2.99.3)
-    minitest (5.9.1)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
+    minitest (5.10.1)
     netrc (0.11.0)
     parser (2.3.1.0)
       ast (~> 2.2)
@@ -43,10 +44,10 @@ GEM
       thor
       thread_safe
     rainbow (2.1.0)
-    rest-client (1.8.0)
+    rest-client (2.0.1)
       http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
@@ -70,18 +71,18 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
-    signalfx (0.1.0)
+    signalfx (1.0.2)
       protobuf (~> 3.5.1, >= 3.5.1)
-      rest-client (~> 1.8)
+      rest-client (~> 2.0)
     simplecov (0.11.2)
       docile (~> 1.1.0)
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     slop (3.6.0)
-    thor (0.19.1)
-    thread_safe (0.3.5)
-    tzinfo (1.2.2)
+    thor (0.19.4)
+    thread_safe (0.3.6)
+    tzinfo (1.2.3)
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
@@ -98,6 +99,3 @@ DEPENDENCIES
   rspec_junit_formatter (~> 0.2)
   rubocop (~> 0.31)
   simplecov (~> 0.10)
-
-BUNDLED WITH
-   1.11.2

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # BetterFx
 Making it _easier_ for you to quickly interact with SignalFx in an idiomatic fashion.
 
+As of v 1.x of the signalfx gem Ruby 2.2 became the minimum supported Ruby version. As such
+ you'll need to be using a compatible Ruby.
+
 ## Usage
 
 Usually you just want to indicate that something occurred

--- a/better_fx.gemspec
+++ b/better_fx.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {spec,features}/*`.split("\n")
   s.homepage =
     "https://github.com/Referly/better_fx"
-  s.add_runtime_dependency "signalfx", "~> 0.1"                         # Apache2 - @link https://github.com/signalfx/signalfx-ruby
+  s.add_runtime_dependency "signalfx", "~> 1.0", ">=1.0.2"              # Apache2 - @link https://github.com/signalfx/signalfx-ruby
   s.add_runtime_dependency "activesupport", "~> 4"                      # MIT - @link https://github.com/rails/rails/blob/master/activesupport/MIT-LICENSE
   s.add_development_dependency "rspec", "~> 3.2"                        # MIT - @link https://github.com/rspec/rspec/blob/master/License.txt
   s.add_development_dependency "byebug", "~> 3.5"                       # BSD (content is BSD) https://github.com/deivid-rodriguez/byebug/blob/master/LICENSE

--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ machine:
   # Version of ruby to use
   ruby:
     version:
-      2.1.3
+      2.2.7
 
 test:
   override:

--- a/lib/better_fx/version.rb
+++ b/lib/better_fx/version.rb
@@ -1,4 +1,4 @@
 module BetterFx
-  VERSION = "1.0.0".freeze
-  VERSION_DATE = "2016-10-13".freeze
+  VERSION = "2.0.0".freeze
+  VERSION_DATE = "2017-04-03".freeze
 end


### PR DESCRIPTION
 - Allows us to get rid of the initialize end console output
 - This necessitates an update to Ruby 2.2 or later